### PR TITLE
fix a double message of "init headless-browser"

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func getCredentials() (string, string) {
 // login with hardware MFA
 func ssoLogin(mfa_code string, url string) {
 	username, passphrase := getCredentials()
-	spinner.Message(color.MagentaString("init headless-browser \n"))
+	spinner.Message(color.MagentaString("init headless-browser"))
 	spinner.Pause()
 	browser := rod.New().MustConnect().Trace(false)
 	defer browser.MustClose()


### PR DESCRIPTION
fix the double "init headless-browser" message
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/679393/195177407-5a9728fd-db0f-4064-aa40-b9db95d99c88.png">
